### PR TITLE
Misc: use cmdline event for custom packersync cmd etc

### DIFF
--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -17,7 +17,7 @@ autocmd("FileType", {
 })
 
 -- wrap the PackerSync command to warn people before using it in NvChadSnapshots
-autocmd("VimEnter", {
+autocmd("CmdlineEnter", {
    callback = function()
       vim.cmd "command! -nargs=* -complete=customlist,v:lua.require'packer'.plugin_complete PackerSync lua require('core.utils').packer_sync(<f-args>)"
    end,

--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -21,7 +21,7 @@ opt.cul = true -- cursor line
 
 -- Indenting
 opt.expandtab = true
-opt.shiftwidth = 2
+opt.shiftwidth = 3
 opt.smartindent = true
 
 opt.fillchars = { eob = " " }

--- a/lua/plugins/configs/treesitter.lua
+++ b/lua/plugins/configs/treesitter.lua
@@ -10,7 +10,6 @@ require("base46").load_highlight "treesitter"
 local options = {
    ensure_installed = {
       "lua",
-      "vim",
    },
    highlight = {
       enable = true,


### PR DESCRIPTION
remove vim tsparser as it is adviced to have 100% lua config and vim.cmd adds a lil overhead as compared to native vim api functions, increase shiftwidth as it looks better